### PR TITLE
Move router link to div

### DIFF
--- a/src/app/components/card/card.component.html
+++ b/src/app/components/card/card.component.html
@@ -1,6 +1,10 @@
-<div class="w-[200px] h-[270px] my-1" *ngIf="anime" [routerLink]="['/']">
+<div
+  class="w-[200px] h-[270px] my-1"
+  *ngIf="anime"
+  [routerLink]="['details', anime._id]"
+>
   <!-- TODO : remplacer le lien '/' du routerLink par le lien de l'anime spécifique une fois la page Details terminé -->
   <img [src]="anime.image" alt="poster" class="w-full h-full object-cover" />
-  <p [routerLink]="['details', anime._id]">{{ anime.title }}</p>
+  <p>{{ anime.title }}</p>
   <p>{{ anime.type }}</p>
 </div>


### PR DESCRIPTION
## ❌ Problème

Le clique sur le div de l'animé mène vers la page principale.


## 🎁 Proposition

- Ajouter une page détails.
- Configurer la route /details/:id sur cette page.
- Ajouter un routerlink dans les cartes des animes vers la route de la page détails de l'animée.


## 🌈 Remarques



## 💯 Pour tester
```sh
npm run start
```
